### PR TITLE
Remove enviroment based configuration loading

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,16 +5,8 @@ var crypto = require('crypto');
 var async = require('async');
 var mime = require('mime');
 
-function evernote (config) {
-  var options = {};
-
-  if (process.env.NODE_ENV === 'production') {
-    options.token = config.production.token;
-    options.sandbox = false;
-  } else {
-    options.token = config.develop.token;
-    options.sandbox = true;
-  }
+function evernote (options) {
+  var options = options || {};
 
   var client = new Evernote.Client({
     token: options.token,


### PR DESCRIPTION
I prefer to handle environment based configuration further up the stack. So that modules don't have to be aware of what environment they're in, they're just given the correct configuration from scratch.

Here's a little goody bag of diffs you're welcome to :smile_cat: if it's a big problem for others.
